### PR TITLE
Remove instance of Suburban

### DIFF
--- a/src/com/maps/OresomeBattlesMaps.java
+++ b/src/com/maps/OresomeBattlesMaps.java
@@ -41,7 +41,7 @@ public class OresomeBattlesMaps extends JavaPlugin {
 	new Skyislands(this);
 	new Fosscrest(this);
 	new Solitude(this);
-	new Suburban(this);
+//	new Suburban(this);
 
     }
 


### PR DESCRIPTION
If one team gets the diamonds / tnt / enchant books / enchanted sign.

The game is already over.

(I don't expect this to be pulled, but ?)

Suggested Changes : Remove the enchants / diamonds.

This would be a great map.
