### PR TITLE
[Fix] Grapple Hook Velocity while in mid-air.

### DIFF
--- a/src/com/oresomecraft/BattleMaps/classes/Perro.java
+++ b/src/com/oresomecraft/BattleMaps/classes/Perro.java
@@ -247,6 +247,7 @@ public class Perro extends BattleMap implements IBattleMap, Listener {
 
                 if (shooter instanceof Player) {
                     Player p = (Player) shooter;
+                    p.setVelocity(new Vector(0,0,0));
                     Location loc = p.getLocation();
                     ItemStack is = p.getItemInHand();
                     Material mat = is.getType();


### PR DESCRIPTION
Fixes issue when flying with the grapple hook (continually grappling
while in mid air) adding velocity and killing you when you fall a small
distance.
