### PR TITLE
Prevent Shovels from dropping upon death

### DIFF
--- a/src/com/oresomecraft/BattleMaps/maps/Spleef.java
+++ b/src/com/oresomecraft/BattleMaps/maps/Spleef.java
@@ -11,6 +11,7 @@ public class Spleef extends BattleMap implements IBattleMap, Listener {
 
     public Spleef() {
         super.initiate(this, name, fullName, creators, modes);
+        disableDrops(new Material[]{Material.DIAMOND_SPADE});
     }
 
     // Map details


### PR DESCRIPTION
Might do something about the PvP aspect to reduce damage (at the moment, a hit from a shovel is 2.5 hearts damage) in the future.
