### PR TITLE
Remove the dropping of sword swords on Electricity because...

### DIFF
--- a/src/com/oresomecraft/BattleMaps/maps/Electricity.java
+++ b/src/com/oresomecraft/BattleMaps/maps/Electricity.java
@@ -14,7 +14,7 @@ public class Electricity extends BattleMap implements IBattleMap, Listener {
     public Electricity() {
         super.initiate(this, name, fullName, creators, modes);
         setAllowBuild(false);
-        disableDrops(new Material[]{Material.GOLD_LEGGINGS, Material.GOLD_CHESTPLATE, Material.GOLD_HELMET, Material.GOLD_BOOTS});
+        disableDrops(new Material[]{Material.GOLD_LEGGINGS, Material.GOLD_CHESTPLATE, Material.GOLD_HELMET, Material.GOLD_BOOTS, Material.STONE_SWORD});
     }
 
     String name = "electricity";


### PR DESCRIPTION
...its very annoying to have 36 stone swords in your inventory and can't pick up anything else.
