### PR TITLE
Add a more efficient way of protecting regions with Cuboid objects

### DIFF
--- a/src/com/oresomecraft/maps/Map.java
+++ b/src/com/oresomecraft/maps/Map.java
@@ -3,9 +3,12 @@ package com.oresomecraft.maps;
 import com.oresomecraft.OresomeBattles.api.BattlePlayer;
 import com.oresomecraft.OresomeBattles.api.BattlesAccess;
 import com.oresomecraft.OresomeBattles.api.Gamemode;
+import com.oresomecraft.OresomeBattles.api.Team;
 import com.oresomecraft.OresomeBattles.api.events.ClearSpawnsEvent;
 import com.oresomecraft.OresomeBattles.api.events.InventoryEvent;
 import com.oresomecraft.maps.battles.BattleMap;
+import com.oresomecraft.maps.object.Cuboid;
+import com.oresomecraft.maps.object.GlobalController;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -364,6 +367,24 @@ public abstract class Map implements Listener {
                 }
             }
         }, 100L, 100L);
+    }
+
+    /**
+     * ***************************************************************
+     * Methods to interact with MapsPlugin                       *
+     * ***************************************************************
+     */
+
+    public void protectRegion(Cuboid c) {
+        GlobalController.newProtectedRegion(c);
+    }
+
+    public Cuboid newCuboid(int x1, int x2, int y1, int y2, int z1, int z2) {
+        return new Cuboid(new Location(w, x1, y1, z1), new Location(w, x2, y2, z2), null);
+    }
+
+    public Cuboid perTeamCuboid(Team[] teams, int x1, int x2, int y1, int y2, int z1, int z2) {
+        return new Cuboid(new Location(w, x1, y1, z1), new Location(w, x2, y2, z2), teams);
     }
 
     /**

--- a/src/com/oresomecraft/maps/MapsPlugin.java
+++ b/src/com/oresomecraft/maps/MapsPlugin.java
@@ -1,5 +1,6 @@
 package com.oresomecraft.maps;
 
+import com.oresomecraft.maps.object.GlobalController;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.*;
@@ -35,6 +36,7 @@ public class MapsPlugin extends JavaPlugin {
 
     public void onEnable() {
         oresomebattlesConfig = YamlConfiguration.loadConfiguration(new File("plugins/OresomeBattles/config.yml"));
+        new GlobalController(this);
 
         if (oresomebattlesConfig.getBoolean("arcade_mode")) { // Is Arcade server?
             loadMaps(ARCADE_MAPS_PACKAGE);

--- a/src/com/oresomecraft/maps/battles/maps/ClashOfClayII.java
+++ b/src/com/oresomecraft/maps/battles/maps/ClashOfClayII.java
@@ -23,6 +23,8 @@ public class ClashOfClayII extends BattleMap implements IBattleMap, Listener {
         setTDMTime(15);
         setCPTime(10);
         disableDrops(new Material[]{Material.DIAMOND_HELMET, Material.WOOD_SWORD});
+        protectRegion(newCuboid(255, 246, 69, 88, -33, -19));
+        protectRegion(newCuboid(15, 23, 70, 88, -17, -30));
     }
 
     String name = "clashofclayii";
@@ -103,10 +105,6 @@ public class ClashOfClayII extends BattleMap implements IBattleMap, Listener {
                 event.setCancelled(true);
             if (event.getBlock().getLocation().distance(new Location(event.getBlock().getWorld(), 144, 79, -30)) <= 5)
                 event.setCancelled(true);
-
-            //Spawn Breaking
-            if (contains(loc, 255, 246, 69, 88, -33, -19)) event.setCancelled(true);
-            if (contains(loc, 15, 23, 70, 88, -17, -30)) event.setCancelled(true);
         }
     }
 
@@ -119,15 +117,6 @@ public class ClashOfClayII extends BattleMap implements IBattleMap, Listener {
                 event.setCancelled(true);
             if (event.getBlock().getLocation().distance(new Location(event.getBlock().getWorld(), 144, 79, -30)) <= 5)
                 event.setCancelled(true);
-
-            //Dud method that doesn't work, don't know why it's here.
-            if (event.getBlock().getType() == Material.LAVA) {
-                event.setCancelled(true);
-            }
-
-            //Spawn placing
-            if (contains(loc, 255, 246, 69, 88, -33, -19)) event.setCancelled(true);
-            if (contains(loc, 15, 23, 70, 88, -17, -30)) event.setCancelled(true);
         }
     }
 }

--- a/src/com/oresomecraft/maps/object/Cuboid.java
+++ b/src/com/oresomecraft/maps/object/Cuboid.java
@@ -1,0 +1,147 @@
+package com.oresomecraft.maps.object;
+
+import com.oresomecraft.OresomeBattles.api.BattlePlayer;
+import com.oresomecraft.OresomeBattles.api.Team;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+
+public class Cuboid implements Iterable<Block> {
+    protected String worldName;
+    protected int x1, y1, z1;
+    protected int x2, y2, z2;
+    protected Team[] appliedTeams;
+
+    public Cuboid(Location l1, Location l2, Team[] teams) {
+        if (l1 == null || l2 == null)
+            throw new NullPointerException("Location can't be null");
+        else if (l1.getWorld() == null)
+            throw new IllegalStateException("Can't create a Cuboid for an unloaded world");
+        else if (!l1.getWorld().getName().equals(l2.getWorld().getName()))
+            throw new IllegalStateException("Can't create a Cuboid between two different worlds");
+        if (teams == null)
+            teams = new Team[]{Team.TDM_BLUE, Team.CP_BLUE, Team.CP_RED, Team.CTF_BLUE, Team.CTF_RED, Team.FFA, Team.HUMANS,
+                    Team.KOTH_BLUE, Team.KOTH_RED, Team.LMS, Team.LTS_BLUE, Team.LTS_RED, Team.ZOMBIES};
+        worldName = l1.getWorld().getName();
+        appliedTeams = teams;
+        x1 = Math.min(l1.getBlockX(), l2.getBlockX());
+        y1 = Math.min(l1.getBlockY(), l2.getBlockY());
+        z1 = Math.min(l1.getBlockZ(), l2.getBlockZ());
+        x2 = Math.max(l1.getBlockX(), l2.getBlockX());
+        y2 = Math.max(l1.getBlockY(), l2.getBlockY());
+        z2 = Math.max(l1.getBlockZ(), l2.getBlockZ());
+    }
+
+    public boolean isInside(Location loc) {
+        if (!loc.getWorld().getName().equals(worldName))
+            return false;
+        int x = loc.getBlockX();
+        int y = loc.getBlockY();
+        int z = loc.getBlockZ();
+        return x >= x1 && x <= x2 && y >= y1 && y <= y2 && z >= z1 && z <= z2;
+    }
+
+    public boolean checkLocation(BattlePlayer p) {
+        if (!p.getLocation().getWorld().getName().equals(worldName))
+            return false;
+        int x = p.getLocation().getBlockX();
+        int y = p.getLocation().getBlockY();
+        int z = p.getLocation().getBlockZ();
+        for (Team t : appliedTeams) {
+            if (t == p.getTeam()) return x >= x1 && x <= x2 && y >= y1 && y <= y2 && z >= z1 && z <= z2;
+        }
+        return false;
+    }
+
+    public boolean checkLocation(Location l, Team team) {
+        if (!l.getWorld().getName().equals(worldName))
+            return false;
+        int x = l.getBlockX();
+        int y = l.getBlockY();
+        int z = l.getBlockZ();
+        for (Team t : appliedTeams) {
+            if (t == team) return x >= x1 && x <= x2 && y >= y1 && y <= y2 && z >= z1 && z <= z2;
+        }
+        return false;
+    }
+
+    public void setBlocks(Material material) {
+        if (material.isBlock())
+            throw new IllegalArgumentException("'" + material.name() + "' isn't a valid block material");
+        for (Block b : this)
+            b.setType(material);
+    }
+
+    public boolean hasReachedHorizontalBorder(Location loc) {
+        int x = loc.getBlockX();
+        int z = loc.getBlockZ();
+        return x == x1 || x == x2 || z == z1 || z == z2;
+    }
+
+    public List<Block> getBlocks() {
+        World world = getWorld();
+        List<Block> blocks = new ArrayList<Block>();
+        for (int x = x1; x <= x2; x++)
+            for (int z = z1; z <= z2; z++)
+                for (int y = y1; y <= y2; y++)
+                    blocks.add(world.getBlockAt(x, y, z));
+        return blocks;
+    }
+
+    public int getSizeX() {
+        return (x2 - x1) + 1;
+    }
+
+    public int getSizeY() {
+        return (y2 - y1) + 1;
+    }
+
+    public int getSizeZ() {
+        return (z2 - z1) + 1;
+    }
+
+    public int getVolume() {
+        return getSizeX() * getSizeY() * getSizeZ();
+    }
+
+    public Location getLowerNE() {
+        return new Location(this.getWorld(), this.x1, this.y1, this.z1);
+    }
+
+    public Location getUpperSW() {
+        return new Location(this.getWorld(), this.x2, this.y2, this.z2);
+    }
+
+    public World getWorld() {
+        World world = Bukkit.getWorld(worldName);
+        if (world == null)
+            throw new IllegalStateException("World '" + this.worldName + "' is not loaded");
+        return world;
+    }
+
+    public Location getHorizontalMirrorLocation(Location loc) {
+        int x = loc.getBlockX();
+        int z = loc.getBlockZ();
+        boolean xBorder = x == x1 || x == x2;
+        boolean x1Border = xBorder ? x == x1 : false;
+        boolean zBorder = z == z1 || z == z2;
+        boolean z1Border = zBorder ? z == z1 : false;
+        if (xBorder)
+            loc.setX(x1Border ? x2 : x1 + 1);
+        if (zBorder)
+            loc.setZ(z1Border ? z2 : z1 + 1);
+        return loc;
+    }
+
+    @Override
+    public Iterator<Block> iterator() {
+        return getBlocks().iterator();
+    }
+}

--- a/src/com/oresomecraft/maps/object/GlobalController.java
+++ b/src/com/oresomecraft/maps/object/GlobalController.java
@@ -1,0 +1,65 @@
+package com.oresomecraft.maps.object;
+
+import com.oresomecraft.OresomeBattles.api.BattlePlayer;
+import com.oresomecraft.maps.MapsPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+import java.util.ArrayList;
+
+public class GlobalController implements Listener {
+
+    //Controller Attributes
+    MapsPlugin plugin;
+    private static ArrayList<Cuboid> cuboids = new ArrayList<Cuboid>();
+
+    public GlobalController(MapsPlugin pl) {
+        plugin = pl;
+        pl.getServer().getPluginManager().registerEvents(this, pl);
+    }
+
+    /**
+     * This event is to control cuboid regions and cancel them if they contain
+     *
+     * @param event An event called by the server
+     */
+    @EventHandler
+    public void onBreak(BlockBreakEvent event) {
+        for (Cuboid c : cuboids) {
+            if (!c.getWorld().getName().equals(event.getBlock().getWorld().getName())) break;
+            if (c.checkLocation(BattlePlayer.getBattlePlayer(event.getPlayer()))) {
+                //Don't allow any further iteration
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    /**
+     * This event is to control cuboid regions and cancel them if they contain
+     *
+     * @param event An event called by the server
+     */
+    @EventHandler
+    public void onBreak(BlockPlaceEvent event) {
+        for (Cuboid c : cuboids) {
+            if (!c.getWorld().getName().equals(event.getBlock().getWorld().getName())) break;
+            if (c.checkLocation(BattlePlayer.getBattlePlayer(event.getPlayer()))) {
+                //Don't allow any further iteration
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    /**
+     * A method to add a new protected cuboid region
+     *
+     * @param c A cuboid
+     */
+    public static void newProtectedRegion(Cuboid c) {
+        cuboids.add(c);
+    }
+}


### PR DESCRIPTION
This can be more efficient because all cuboids are iterated through one listener instead of one per class (if they use protecting regions on buildable maps)
