### PR TITLE
Remove LTS and Infection

### DIFF
--- a/src/com/oresomecraft/maps/battles/maps/TelluricPath.java
+++ b/src/com/oresomecraft/maps/battles/maps/TelluricPath.java
@@ -34,7 +34,7 @@ public class TelluricPath extends BattleMap implements IBattleMap, Listener {
     String name = "telluricpath";
     String fullName = "Telluric Path";
     String creators = "__R3 ";
-    Gamemode[] modes = {Gamemode.CTF, Gamemode.LTS, Gamemode.INFECTION};
+    Gamemode[] modes = {Gamemode.CTF};
 
     public void readyTDMSpawns() {
 


### PR DESCRIPTION
Removing LTS because the games go for too long and loses the player count.
Same for infection.
