### PR TITLE
Remove Infection from Battlement

### DIFF
--- a/src/com/oresomecraft/maps/battles/maps/Battlement.java
+++ b/src/com/oresomecraft/maps/battles/maps/Battlement.java
@@ -19,7 +19,7 @@ public class Battlement extends BattleMap implements Listener {
     String name = "battlement";
     String fullName = "Battlement";
     String creators = "ShaunDepro97 ";
-    Gamemode[] modes = {Gamemode.TDM, Gamemode.FFA, Gamemode.INFECTION};
+    Gamemode[] modes = {Gamemode.TDM, Gamemode.FFA};
 
     public void readyTDMSpawns() {
 


### PR DESCRIPTION
Removed because of the fact that people keep hiding in weird places in the trees and/or on the hill. This map doesn't really suit Infection either, it's more of a TDM-like map. Modes still available on Battlement as of this fix; 
-TDM and FFA
