### PR TITLE
Remove pickaxe and sword dropping on Clash of Clay II

### DIFF
--- a/src/com/oresomecraft/maps/battles/maps/ClashOfClayII.java
+++ b/src/com/oresomecraft/maps/battles/maps/ClashOfClayII.java
@@ -22,7 +22,7 @@ public class ClashOfClayII extends BattleMap implements Listener {
     public ClashOfClayII() {
         super.initiate(this, name, fullName, creators, modes);
         setTDMTime(15);
-        disableDrops(new Material[]{Material.DIAMOND_HELMET, Material.WOOD_SWORD});
+        disableDrops(new Material[]{Material.STONE_PICKAXE, Material.STONE_SWORD});
         disableBlocks(new Material[]{Material.WORKBENCH, Material.PISTON_MOVING_PIECE});
     }
 


### PR DESCRIPTION
Also removed wooden sword and diamond helmet from disableDrops, as they are no longer in the map's spawnkit.
