### PR TITLE
Add cooked beef instead of fish and carrots

### DIFF
--- a/src/com/oresomecraft/maps/battles/maps/SkyVillage.java
+++ b/src/com/oresomecraft/maps/battles/maps/SkyVillage.java
@@ -34,7 +34,7 @@ import org.bukkit.inventory.ItemStack;
 @Attributes(
         allowBuild = false,
         fireSpread = false,
-        disabledDrops = {Material.CARROT_ITEM, Material.COOKED_FISH, Material.ARROW, Material.IRON_CHESTPLATE, Material.IRON_LEGGINGS, Material.BOW, Material.IRON_SWORD, Material.IRON_BOOTS, Material.IRON_HELMET}
+        disabledDrops = {Material.ARROW, Material.IRON_CHESTPLATE, Material.IRON_LEGGINGS, Material.BOW, Material.IRON_SWORD, Material.IRON_BOOTS, Material.IRON_HELMET}
 )
 public class SkyVillage extends BattleMap implements Listener {
 
@@ -84,8 +84,7 @@ public class SkyVillage extends BattleMap implements Listener {
         ItemStack BOW = new ItemStack(Material.BOW, 1);
         ItemStack ARROWS = new ItemStack(Material.ARROW, 64);
         ItemStack IRON_SWORD = new ItemStack(Material.IRON_SWORD, 1);
-        ItemStack COOKED_FISH = new ItemStack(Material.COOKED_FISH, 64);
-        ItemStack CARROT = new ItemStack(Material.CARROT_ITEM, 64);
+        ItemStack COOKED_BEEF = new ItemStack(Material.COOKED_BEEF, 10);
 
         ItemStack IRON_HELMET = new ItemStack(Material.IRON_HELMET, 1);
         ItemStack IRON_CHESTPLATE = new ItemStack(Material.IRON_CHESTPLATE, 1);
@@ -100,8 +99,7 @@ public class SkyVillage extends BattleMap implements Listener {
         i.setItem(0, IRON_SWORD);
         i.setItem(1, BOW);
         i.setItem(2, HEALTH_POTION);
-        i.setItem(3, COOKED_FISH);
-        i.setItem(4, CARROT);
+        i.setItem(3, COOKED_BEEF);
         i.setItem(35, ARROWS);
         i.setItem(8, new ItemStack(Material.ENDER_PEARL, 1));
 


### PR DESCRIPTION
Adding 10 cooked beef instead of a stack of fish and carrots may help improve distaste for this map. Higher saturation food means that people need to eat less meaning less time eating food. This can help people who dont eat often have a full hunger bar for longer and so have natural regen for longer. Cooked beef is a droppable item in the config.
